### PR TITLE
Fix totalPopulation calculation

### DIFF
--- a/src/views/v2/Hospitalization7DayNewCasesPlot.vue
+++ b/src/views/v2/Hospitalization7DayNewCasesPlot.vue
@@ -212,9 +212,12 @@ export default class VueComponent extends Vue {
 
     try {
       const susceptible = this.data.filter(v => v.name === 'Susceptible')[0]
-      if (!susceptible) return
+      const totalInfected = this.data.filter(item => item.name === 'Total Infected')[0]
+      const recovered = this.data.filter(item => item.name === 'Recovered')[0]
 
-      const totalPopulation = susceptible.y[0]
+      if (!susceptible || !totalInfected || !recovered) return
+
+      const totalPopulation = susceptible.y[0] + totalInfected.y[0] + recovered.y[0]
       const factor100k = totalPopulation / 100000.0
 
       const seriouslySickCumul = this.data.filter(v => v.name === 'Seriously Sick Cumulative')[0]

--- a/src/views/v2/HospitalizationVaccinationComparison.vue
+++ b/src/views/v2/HospitalizationVaccinationComparison.vue
@@ -229,7 +229,7 @@ export default class VueComponent extends Vue {
     var kh_geimpft = []
     var kh_ungeimpft = []
 
-    const totalPopulation = susceptible.y[0]
+    const totalPopulation = susceptible.y[0] + totalInfected.y[0] + recovered.y[0]
     let factor100k = totalPopulation / 100000.0
 
     for (var i = 0; i < seriouslySick.x.length; i++) {

--- a/src/views/v2/MutationsPlot.vue
+++ b/src/views/v2/MutationsPlot.vue
@@ -41,8 +41,14 @@ export default class VueComponent extends Vue {
   private mounted() {
     console.log(this.strainValues)
     this.loadStartURL()
+
+    // If the simulation begins in the middle of a pandemic, then we need to add together susceptible, infected, and
+    // recovered agents to get the total population. --jr nov'22
     const susceptible = this.data.filter(item => item.name === 'Susceptible')[0]
-    const totalPopulation = susceptible.y[0]
+    const totalInfected = this.data.filter(item => item.name === 'Total Infected')[0]
+    const recovered = this.data.filter(item => item.name === 'Recovered')[0]
+
+    const totalPopulation = susceptible.y[0] + totalInfected.y[0] + recovered.y[0]
     this.factor100k = totalPopulation / 100000.0
 
     this.calculateValues()

--- a/src/views/v2/WeeklyInfectionsPlot.vue
+++ b/src/views/v2/WeeklyInfectionsPlot.vue
@@ -255,9 +255,14 @@ export default class VueComponent extends Vue {
     this.layout.xaxis.range[0] = this.$store.state.graphStartDate
     this.layout.xaxis.range[1] = this.endDate
 
+    // If the simulation begins in the middle of a pandemic, then we need to add together susceptible, infected, and
+    // recovered agents to get the total population. --jr nov'22
     const susceptible = this.data.filter(item => item.name === 'Susceptible')[0]
+    const totalInfected = this.data.filter(item => item.name === 'Total Infected')[0]
+    const recovered = this.data.filter(item => item.name === 'Recovered')[0]
 
-    const totalPopulation = susceptible.y[0]
+    const totalPopulation = susceptible.y[0] + totalInfected.y[0] + recovered.y[0]
+
     const factor100k = totalPopulation / 100000.0
     const sevenDays = 7
 


### PR DESCRIPTION
In several plots, the totalPopulation is needed to calculate incidences. Previously, this totalPopulation was gleaned from the the first cell in the infections.txt output file (row: day1, column: "nSusceptible"). This was fine as long no one was infected at the start of the simulation.

Now, we are starting simulations later in the pandemic. Thus, the previous methodology for gleaning the totalPopulation would only give us the susceptible portion of the population. 

With the PR, the total population is calculated by adding the susceptible, infected, and recovered agents together.

I've only made these changes for the V2 plots